### PR TITLE
Adding reference to cluster_type variable

### DIFF
--- a/SAMPLE_CREDENTIAL_CONFIG.yml
+++ b/SAMPLE_CREDENTIAL_CONFIG.yml
@@ -19,6 +19,8 @@ cluster_pod_openshift_pass: <CHANGEME>
 
 cluster_credential_bundle_aws_name: "<CHANGEME>.AWS"
 
+cluster_type: <CHANGEME> #set to 'dev' or 'poc'
+
 rh_user: <CHANGEME>
 rh_pass: <CHANGEME>
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -21,6 +21,7 @@ Configuration variables required by the `provisioning_vars.yml.j2` file to provi
 | `cluster_pod_openshift_user`:   | Openshift cluster pod username |
 | `cluster_pod_openshift_pass`:   | Openshift cluster pod password |
 | `cluster_credential_bundle_aws_name`: | AWS cluster credential bundle name |
+| `cluster_type`: | Cluster type. Should be set to 'dev' or 'poc' |
 | `rh_user`: | [Red Hat registry](https://docs.openshift.com/container-platform/3.11/install/configuring_inventory_file.html#advanced-install-configuring-registry-location) username |
 | `rh_pass`: | [Red Hat registry](https://docs.openshift.com/container-platform/3.11/install/configuring_inventory_file.html#advanced-install-configuring-registry-location) password |
 | `dev_domain`: | Domain name to be used for development environments |

--- a/inventories/group_vars/all/cluster.yml
+++ b/inventories/group_vars/all/cluster.yml
@@ -8,6 +8,8 @@ cluster_pod_openshift_pass: ''
 
 cluster_credential_bundle_aws_name: ''
 
+cluster_type: ''
+
 rh_pool: ''
 
 rh_user: ''


### PR DESCRIPTION
**Summary**
As part of cluster provisioning, we need to ensure that the cluster_type variable is always defined and will either be set to 'dev' or 'poc'