### PR TITLE
Fixed issue with multiple project runs and updated variables

### DIFF
--- a/SAMPLE_CREDENTIAL_CONFIG.yml
+++ b/SAMPLE_CREDENTIAL_CONFIG.yml
@@ -2,19 +2,16 @@
 
 # Vault Password - Master Ansible Vault password used to encrypt all of the following variables. 
 # Please store this password securely for future use as it does not persist after project execution.
-
 vault_password: <CHANGEME>
 
 # AWS_credentials
-
-aws_credentials_list:
+aws_credential_list:
   - dummy
 
 dummy_access_key_id: <CHANGEME>
 dummy_secret_access_key: <CHANGEME>
 
 # cluster.yml
-
 cluster_credential_git_repo: <CHANGEME>
 
 cluster_pod_openshift_user: <CHANGEME>
@@ -34,19 +31,21 @@ htpasswd_username: <CHANGEME>
 htpasswd_password: <CHANGEME>
 
 # integreatly_vault.yml
-
 tower_credential_bundle_vault_name: <CHANGEME>
 integreatly_vault: <CHANGEME>
 
 # letsencrypt.yml
-
-letsencrypt_private_key:
+letsencrypt_private_key: |
     -----BEGIN RSA PRIVATE KEY-----
     <CHANGEME>
     -----END RSA PRIVATE KEY-----
 
-# tower_github_authentication.yml
+# send_grid.yml
+send_grid_user: <CHANGEME>
+send_grid_sender: <CHANGEME>
+send_grid_password: <CHANGEME>
 
+# tower_github_authentication.yml
 social_auth_github_org_name: <CHANGEME>
 social_auth_github_org_key: <CHANGEME>
 social_auth_github_org_secret: <CHANGEME>
@@ -55,29 +54,25 @@ social_auth_github_org_organization_map: "{'<CHANGEME>': {'admins': True, 'users
 social_auth_github_org_team_map: "{'<CHANGEME>': {'organization': '<CHANGEME>', 'users': True}}"
 
 # tower_github_scm.yml
-
 tower_github_scm_password: <CHANGEME>
-tower_github_scm:
+tower_github_scm: |
     -----BEGIN RSA PRIVATE KEY-----
     <CHANGEME>
     -----END RSA PRIVATE KEY-----
 
 # tower_openshift_authentication.yml
-
 tower_openshift_username: <CHANGEME> 
 tower_openshift_password: <CHANGEME>
 tower_openshift_master_url: <CHANGEME>
 
 # tower_ssh.yml
-
 tower_ssh_user: <CHANGEME>
-tower_ssh:
+tower_ssh: |
     -----BEGIN RSA PRIVATE KEY-----
     <CHANGEME>
     -----END RSA PRIVATE KEY-----
 
 # tower_credentials
-
 tower_instance_list:
   - dummy
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -15,7 +15,7 @@ Ansible Vault password used to encrypt all of the following variables. This pass
 Credentials of the target AWS accounts to be used when provisioning new clusters. Multiple AWS environments can be supported. The name of each AWS environment must be added to the `aws_credential_list`, and the associated `access_key_id` and `secret_access_key` credentials also specified with the environment name prefixed to each:
 
 ```bash
-aws_credentials_list:
+aws_credential_list:
   - 'dev'
   - 'prod'
 
@@ -69,7 +69,7 @@ Private key to be used with Lets Encrypt.
 
 ## send_grid.yml
 
-Send Grid credentials to be used to send a notification email if the Compare Project Variables job template fails.
+Send Grid credentials to be used to send a notification email if the Compare Project Variables job fails. Can be left blank if not required.
 
 | Variable | Description | Encrypted |
 | ------ | ----------- | ----------- |
@@ -77,7 +77,7 @@ Send Grid credentials to be used to send a notification email if the Compare Pro
 | `send_grid_sender` | Sender email address | ✔ |
 | `send_grid_password` | Password associated with the API key | ✔ |
 | `send_grid_host` | Send Grid host |  |
-| `send_grid_port` | Send Grid port number |  |
+| `send_grid_port` | Send Grid port number. Default is port 587 |  |
 | `send_grid_email_recipients` | Email address of the intended recipients, comma separated if more than one recipient |  |
 
 ## tower_github_authentication.yml

--- a/roles/credentials/tasks/bootstrap_credentials.yml
+++ b/roles/credentials/tasks/bootstrap_credentials.yml
@@ -3,7 +3,7 @@
 
 - include_tasks: template_aws_credentials.yml
   with_items: 
-        - '{{ aws_credentials_list }}'
+        - '{{ aws_credential_list }}'
 
 - include_tasks: template_tower_credentials.yml
   with_items: 


### PR DESCRIPTION
## Additional Information

https://issues.jboss.org/browse/INTLY-4089

## Verification Steps

1. Ensure all references to `aws_credentials_list` variables aew changed to `aws_credential_list`.
 
2. Add ssh key using magic `|`

    This was added to the following variables in the `SAMPLE_CREDENTIAL_CONFIG.yml` file:
    `letsencrypt_private_key`
    `tower_github_scm`
    `tower_ssh`
    
3. The user should be able to re-run the project to generate a new set of credentials, without any errors occurring

    This can be tested by re-running the `bootstrap.yml` playbook multiple times to generate 
    credentials, ensuring that no error/failures occur.