### PR TITLE
Adding new tower_ssh_user_password variable

### DIFF
--- a/inventories/group_vars/all/tower_ssh.yml
+++ b/inventories/group_vars/all/tower_ssh.yml
@@ -1,4 +1,5 @@
 ---
 tower_ssh_user: ''
 tower_ssh_password: ''
+tower_ssh_user_password: ''
 tower_ssh: ''

--- a/roles/credentials/templates/tower_ssh.yml.j2
+++ b/roles/credentials/templates/tower_ssh.yml.j2
@@ -1,6 +1,7 @@
 ---
 tower_ssh_user: {{ tower_ssh_user }}
 tower_ssh_password: ''
+tower_ssh_user_password: ''
 tower_ssh: !vault
 |
 {{ tower_ssh_enc }}


### PR DESCRIPTION
Adding new `tower_ssh_user_password` variable to support changes made to tower configuration repository: https://github.com/integr8ly/ansible-tower-configuration/pull/114