### PR TITLE
Adding tower_ssh_become_password 

### DIFF
--- a/CREDENTIAL_CONFIG.yml
+++ b/CREDENTIAL_CONFIG.yml
@@ -67,6 +67,7 @@ tower_openshift_master_url: <CHANGEME>
 
 # tower_ssh.yml
 tower_ssh_user: <CHANGEME>
+tower_ssh_become_password: <CHANGEME>
 tower_ssh: |
     -----BEGIN RSA PRIVATE KEY-----
     <CHANGEME>

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -118,6 +118,7 @@ Ansible Tower SSH configuration values.
 | Variable | Description | Encrypted |
 | ------ | ----------- | ----------- |
 | `tower_ssh`  | The SSH key to be copied over to the Ansible tower instance | ✔ |
+| `tower_ssh_become_password`  | sudo password for tower username associated with the tower credentials | ✔ |
 | `tower_ssh_user` | The tower username associated with the tower credentials |  |
 
 ## tower_credentials

--- a/roles/credentials/tasks/bootstrap_credentials.yml
+++ b/roles/credentials/tasks/bootstrap_credentials.yml
@@ -42,6 +42,7 @@
 
           # tower_ssh.yml
         - { name: 'tower_ssh', value: '{{ tower_ssh }}' }
+        - { name: 'tower_ssh_become_password', value: '{{ tower_ssh_become_password }}' }
 
 
 - include_tasks: encrypt_config_file.yml

--- a/roles/credentials/templates/tower_ssh.yml.j2
+++ b/roles/credentials/templates/tower_ssh.yml.j2
@@ -1,6 +1,9 @@
 ---
 tower_ssh_user: {{ tower_ssh_user }}
 tower_ssh_password: ''
+tower_ssh_become_password: !vault
+|
+{{ tower_ssh_become_password_enc }}
 tower_ssh_user_password: ''
 tower_ssh: !vault
 |


### PR DESCRIPTION
As per comments in https://github.com/integr8ly/ansible-tower-configuration/pull/116#issuecomment-555936374. Bootstrap is failing due to tower_ssh_become_password not being set here.

