### PR TITLE
AWS and tower credentials fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The projects `CREDENTIAL_CONFIG.yml` file contains a list of variables which nee
 git clone https://github.com/<forked_repository_org>/tower_dummy_credentials
 ```
 
-1. Change the variable values in the `CREDENTIAL_CONFIG.yml` file. A list of all variables that need to be changed along with their usage can be found [HERE](VARIABLES.md).
+2. Change the variable values in the `CREDENTIAL_CONFIG.yml` file. A list of all variables that need to be changed along with their usage can be found [HERE](VARIABLES.md).
 
-2. From the projects root directory, run the `bootstrap.yml` playbook, specifying the path to the `CREDENTIAL_CONFIG.yml` file.
+3. From the projects root directory, run the `bootstrap.yml` playbook, specifying the path to the `CREDENTIAL_CONFIG.yml` file.
 
 ```bash
 ansible-playbook -i ./inventories/hosts bootstrap.yml --extra-vars='@CREDENTIAL_CONFIG.yml'

--- a/roles/credentials/tasks/bootstrap_credentials.yml
+++ b/roles/credentials/tasks/bootstrap_credentials.yml
@@ -1,6 +1,8 @@
 ---
 - include_tasks: vault_password.yml
 
+- include_tasks: delete_credentials.yml
+
 - include_tasks: template_aws_credentials.yml
   with_items: 
         - '{{ aws_credential_list }}'

--- a/roles/credentials/tasks/delete_credentials.yml
+++ b/roles/credentials/tasks/delete_credentials.yml
@@ -1,0 +1,13 @@
+---
+- name: Find AWS credentials and tower instance list files
+  find:
+    paths: ./inventories/group_vars/all
+    patterns: "*_list.yml"
+  register: files_to_delete
+
+- name: Deleting list files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ files_to_delete.files }}"
+  register: files

--- a/roles/credentials/tasks/template_aws_credentials.yml
+++ b/roles/credentials/tasks/template_aws_credentials.yml
@@ -16,4 +16,4 @@
 - name: Template AWS credentials
   template: 
     src: aws_credentials/aws_credentials.yml.j2
-    dest: inventories/group_vars/all/{{ item }}_aws_credentials.yml
+    dest: inventories/group_vars/all/{{ item }}_aws_credentials_list.yml

--- a/roles/credentials/tasks/template_tower_credentials.yml
+++ b/roles/credentials/tasks/template_tower_credentials.yml
@@ -16,4 +16,4 @@
 - name: Template tower credentials
   template: 
     src: tower_credentials/tower_credentials.yml.j2
-    dest: inventories/group_vars/all/{{ item }}_tower_credentials.yml
+    dest: inventories/group_vars/all/{{ item }}_tower_credentials_list.yml

--- a/roles/credentials/templates/aws_credentials_list.yml.j2
+++ b/roles/credentials/templates/aws_credentials_list.yml.j2
@@ -1,0 +1,5 @@
+---
+aws_credential_list:
+  {% for item in aws_credential_list %}
+- {{ item }}
+  {% endfor %}

--- a/roles/credentials/templates/tower_instance_list.yml.j2
+++ b/roles/credentials/templates/tower_instance_list.yml.j2
@@ -1,0 +1,5 @@
+---
+tower_instance_list:
+  {% for item in tower_instance_list %}
+- {{ item }}
+  {% endfor %}


### PR DESCRIPTION
## Fixes

1. The list of AWS credentials and tower instances were not being generated.

   These 2 files are now dynamically generated during project execution and are created with the following names: `aws_credentials_list.yml`,  `tower_instance_list.yml`.

2. Auto-generated files were not being cleaned-up

    On initial project execution, a number of files related to AWS credentials and Tower instances are 
    auto-generated. If the user re-runs the project, these files still exist. Change have been 
    implemented to regenerate these files whenever the project is run.

3. README numbering

    The numbering is the `Setup` section of the README was incorrect.

## Verification

1. Using this feature branch, update the `CREDENTIAL_CONFIG.yml` file to include a multiple AWS credentials and Tower instances, e.g:

```
# AWS credentials list
aws_credential_list:
  - dummy
  - test

dummy_access_key_id: <CHANGEME>
dummy_secret_access_key: <CHANGEME>

test_access_key_id: <CHANGEME>
test_secret_access_key: <CHANGEME>

# Tower instance list
tower_instance_list:
  - dummy
  - test

dummy_tower_host: <CHANGEME>
dummy_tower_verify_ssl: True
dummy_tower_username: <CHANGEME>
dummy_tower_password: <CHANGEME>

test_tower_host: <CHANGEME>
test_tower_verify_ssl: True
test_tower_username: <CHANGEME>
test_tower_password: <CHANGEME>
```

2. Execute the project. A corresponding `<>_aws_credentials.yml` and `<>_tower_credentials.yml` file should be created for every set of AWS credentials and tower instances specified. Ensure these are populated with the correct values.

3. 2 files containing a list of the specified AWS credentials and Tower instances should be created and populated with the correct values: `aws_credentials_list.yml`,  `tower_instance_list.yml`.

4. Make some changes to the AWS credentials and Tower instances in the `CREDENTIAL_CONFIG.yml` file and re-run the project. New files should be generated and any old files removed.