### PR TITLE
Merge pull request #16 from integr8ly/variables_for_cluster_provisioning

### DIFF
--- a/CREDENTIAL_CONFIG.yml
+++ b/CREDENTIAL_CONFIG.yml
@@ -30,6 +30,10 @@ poc_domain: <CHANGEME>
 htpasswd_username: <CHANGEME>
 htpasswd_password: <CHANGEME>
 
+cert_mail_address: <CHANGEME>
+
+cluster_backup_bucket_name: <CHANGEME>
+
 # integreatly_vault.yml
 tower_credential_bundle_vault_name: <CHANGEME>
 integreatly_vault: <CHANGEME>

--- a/CREDENTIAL_CONFIG.yml
+++ b/CREDENTIAL_CONFIG.yml
@@ -30,7 +30,7 @@ poc_domain: <CHANGEME>
 htpasswd_username: <CHANGEME>
 htpasswd_password: <CHANGEME>
 
-cert_mail_address: <CHANGEME>
+cert_email_address: <CHANGEME>
 
 cluster_backup_bucket_name: <CHANGEME>
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -65,7 +65,7 @@ Private key to be used with Lets Encrypt. Be sure to use openssl when generating
 | Variable | Description | Encrypted |
 | ------ | ----------- | ----------- |
 | `letsencrypt_private_key` | The user generated private key to be used with Lets Encrypt | ✔ |
-| `cert_mail_address` | Email address used for generating letsencrypt certs | |
+| `cert_email_address` | Email address used for generating letsencrypt certs | |
 
 ## send_grid.yml
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -47,6 +47,7 @@ Configuration variables required by the `provisioning_vars.yml.j2` file to provi
 | `poc_domain` | Domain name to be used for Proof of Concept (POC) environments |  |
 | `htpasswd_username` | Openshift cluster admin username |  |
 | `htpasswd_password` | htpasswd encrypted Openshift cluster admin password | ✔ |
+| `cluster_backup_bucket_name` | Name of cluster backup S3 bucket | |
 
 ## integreatly_vault.yml
 
@@ -64,6 +65,7 @@ Private key to be used with Lets Encrypt. Be sure to use openssl when generating
 | Variable | Description | Encrypted |
 | ------ | ----------- | ----------- |
 | `letsencrypt_private_key` | The user generated private key to be used with Lets Encrypt | ✔ |
+| `cert_mail_address` | Email address used for generating letsencrypt certs | |
 
 ## send_grid.yml
 

--- a/roles/credentials/templates/cluster.yml.j2
+++ b/roles/credentials/templates/cluster.yml.j2
@@ -64,7 +64,7 @@ g_enable_monitoring: false
 g_run_config_loop: false
 
 # Backups
-cluster_backup_bucket_name: "integreatly-cert-backups"
+cluster_backup_bucket_name: "{{ cluster_backup_bucket_name }}"
 cluster_backup_integreatly_bucket_name: "{{ '{{' }} oo_clusterid {{ '}}' }}-integreatly-backups"
 cluster_backup_namespace: openshift-integreatly-backups
 cluster_backup_secret_name: s3-credentials

--- a/roles/credentials/templates/letsencrypt.yml.j2
+++ b/roles/credentials/templates/letsencrypt.yml.j2
@@ -3,4 +3,4 @@ letsencrypt_private_key: !vault
 |
 {{ letsencrypt_private_key_enc }}
 
-cert_mail_address: {{ cert_mail_address }}
+cert_email_address: {{ cert_email_address }}

--- a/roles/credentials/templates/letsencrypt.yml.j2
+++ b/roles/credentials/templates/letsencrypt.yml.j2
@@ -2,3 +2,5 @@
 letsencrypt_private_key: !vault
 |
 {{ letsencrypt_private_key_enc }}
+
+cert_mail_address: {{ cert_mail_address }}


### PR DESCRIPTION
Add cert_mail_address so the email associated with the letsencrypt account for generating certs is configurable.

Add cluster_backup_bucket_name so the name of the S3 backup bucket is configurable.