### PR TITLE
Adding CHANGELOG for tracking variable updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Unreleased
+* [INTLY-4759] - Changed vault credential variable name from tower_credential_bundle_vault_name to tower_credential_vault_name
+* [INTLY-4223] - Added tower license variables dummy_tower_license dev_tower_license prod_tower_license
+* [INTLY-4764] - Added cluster provisioning variables cert_email_address cluster_backup_bucket_name


### PR DESCRIPTION
**Summary**
As part of managing variables across multiple credential repos per release, we need to have a CHANGELOG that will track all new/updated variables between RHMI releases