### PR TITLE
Add Makefile for automating credential repo release update process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+SHELL=/bin/bash
+
+sync:
+	scripts/sync.sh ${releasetag}
+
+clean:
+	scripts/clean.sh ${branch}

--- a/README.md
+++ b/README.md
@@ -1,96 +1,149 @@
 # Tower Dummy Credentials Repo
 
-Dummy Credentials repository to demonstrate how to bootstrap a tower instance with CI/CD jobs.
+Dummy credentials repository used to generate organisation specific credential repositories required for bootstrapping RHMI Ansible Tower instances.
+
+**NOTE:** This repository serves as the inventory source for the [Ansible Tower Configuration](https://github.com/integr8ly/ansible-tower-configuration) repository.
 
 ## Getting Started
 
-This project serves as the inventory source for the [Ansible Tower Configuration](https://github.com/integr8ly/ansible-tower-configuration) project.
+### Setup
 
-## Usage 
+1. Fork credentials repository and make private
 
-The projects `CREDENTIAL_CONFIG_TEMPLATE.yml` file contains a list of variables which need to be changed to suit your own tower environment. Copy the file to `CREDENTIAL_CONFIG.yml` and once these variables have been changed, the `bootstrap.yml` playbook consumes the `CREDENTIAL_CONFIG.yml` file, encrypts any variables containing sensitive information using the supplied Ansible vault password, and then places each of the variables into the relevant group_vars file. The `CREDENTIAL_CONFIG.yml` file itself is then encrypted using the same Ansible vault password.
+   **PLEASE READ** This repository should be forked BEFORE proceeding with the below steps. Although any sensitive data will be encrypted via Ansible Vault, it is still recommended that the forked repository be made private. The remainder of this README makes the assumption that all steps going forward are being performed from within the private forked repository.
 
-## Setup
+2. Clone private forked credentials repository locally
 
-**NOTE**: This project should be forked before proceeding with the following setup steps. We still recommend the repository to be private even though all the sensitive informaion will be encrypted.
+        git clone https://github.com/<forked_repository_org>/<forked_repository_name>
 
-1. Clone this project.
+3. Make a copy of the `CREDENTIAL_CONFIG_TEMPLATE.yml` file named `CREDENTIAL_CONFIG.yml` in the root of the repository
 
-        git clone https://github.com/<forked_repository_org>/tower_dummy_credentials
-        
-2. Make a copy of the `CREDENTIAL_CONFIG_TEMPLATE.yml` file and set the variables for your tower instance in the copied file. A list of all variables that need to be changed along with their usage can be found [HERE](VARIABLES.md).
-        
         cp CREDENTIAL_CONFIG_TEMPLATE.yml CREDENTIAL_CONFIG.yml
-        
-3. From the projects root directory, run the `bootstrap.yml` playbook, specifying the path to the `CREDENTIAL_CONFIG.yml` file.
+
+4. Populate newly copied `CREDENTIAL_CONFIG.yml` file with correct values for each variable. A list of all variables and their usage can be found in the [VARIABLES.md](https://github.com/integr8ly/tower_dummy_credentials/blob/master/VARIABLES.md) file of the upstream dummy repository
+
+5. Once all variable values have been set in the `CREDENTIAL_CONFIG.yml` file, run the `bootstrap.yml` playbook from the root of the repository and specify the path to the `CREDENTIAL_CONFIG.yml` file.
 
         ansible-playbook -i ./inventories/hosts bootstrap.yml --extra-vars='@CREDENTIAL_CONFIG.yml'
-        git add CREDENTIAL_CONFIG.yaml
 
-4. Sensitive information is encrypted now, push to the GitHub (Despite the encryption, we still recommend pushing to the private repository).
+   **NOTE:** All sensitive information should now be encrypted including the copied `CREDENTIAL_CONFIG.yml` file with the password set for the `vault_password` variable.
 
-## Adding new variables
+6. Next, run the cleandown task to remove any non-essential files and directories in the forked repository
+
+        make clean branch=add_encrypted_data
+
+7. Push all changes to remote
+
+        git add .
+        git commit -am "Initial commit containing all encrypted data"
+        git push origin add_encrypted_data
+
+8. Finally, create a new pull request from the `add_encrypted_data` feature branch referenced above and merge back to the `master` branch of the private forked repository
+
+### Adding new variables
 
 The following steps outline the process of adding new variables to the project. Please ensure that all new variables are also added to the [VARIABLES.md](VARIABLES.md) file.
 
-### Encrypted
+#### Encrypted
 
 1. Add the variable to the  `CREDENTIAL_CONFIG.yml` file with a default value of `<CHANGEME>`.
 
 2. Add an entry within the `with_items` section of the [bootstrap_credentials.yml](roles/credentials/tasks/bootstrap_credentials.yml#L13) file, replacing `new_variable` in the both the name and value fields with the name of the new variable.
 
-```bash
- - { name: 'new_variable', value: '{{ new_variable }}' }
- ```
+        - { name: 'new_variable', value: '{{ new_variable }}' }
 
 3. Add the new variable to the relevant file template located in `roles/credentials/templates` using the below format, ensuring that the variable to substitute in the template has `_enc` appended to the end of the variable name.
 
-```bash
-new_variable: !vault
-|
-{{ new_variable_enc }}
- ```
+        new_variable: !vault
+        |
+        {{ new_variable_enc }}
 
- ### Plaintext
+#### Plaintext
 
  1. Add the variable to the  `CREDENTIAL_CONFIG_TEMPLATE.yml` file with a value of `<CHANGEME>`.
-   
+
  2. Add the new variable to the relevant file template located in `roles/credentials/templates`, ensuring that the variables value is the name of the variable, placed within brackets.
 
-```bash
- new_variable: {{ new_variable }}
- ```
+        new_variable: {{ new_variable }}
 
-## Decryption
+### Decryption
 
 Encrypted files and variables can be decrypted using the commands below, where the password is the `vault-password` variable value specified in your local copy of the `CREDENTIAL_CONFIG.yml` file.
 
-### Files
+#### Files
 
-```bash
-ansible-vault decrypt '<path-to-file-to-decrypt>'
- ```
+        ansible-vault decrypt '<path-to-file-to-decrypt>'
 
-### Variables
+#### Variables
 
-```bash
-ansible localhost -m debug -a var='<variable-name>' -e '@<path-to-file>' --ask-vault-pass
-```
+        ansible localhost -m debug -a var='<variable-name>' -e '@<path-to-file>' --ask-vault-pass
 
-## Updating encrypted variables
+### Updating encrypted variables
 
 The `bootstrap.yml` playbook can be re-run to update variable values.
 
 1. Decrypt the `CREDENTIAL_CONFIG.yml` file.
 
-```bash
-ansible-vault decrypt 'CREDENTIAL_CONFIG.yml'
-```
+        ansible-vault decrypt 'CREDENTIAL_CONFIG.yml'
 
 2. Make the required update/s.
 
 3. Re-run the `bootstrap.yml` playbook.
 
-```bash
-ansible-playbook -i ./inventories/hosts bootstrap.yml --extra-vars='@CREDENTIAL_CONFIG.yml'
-```
+        ansible-playbook -i ./inventories/hosts bootstrap.yml --extra-vars='@CREDENTIAL_CONFIG.yml'
+
+### Updating private credential repositories
+
+Following the creation of a new release tag on the Tower Dummy credential repository, all private repositories need to be updated to reflect the latest variables and code changes. Below is a list of steps for updating a private credentials repository to a specific release
+
+1. Clone private credentials repository locally
+
+        git clone git@github.com:<forked_repository_org>/<forked_repository_name>.git
+
+2. Validate remote configuration
+
+   The `make sync` task makes some assumptions around how GIT remotes are configured in the local repository
+
+   Ensure the origin and dummy remotes are setup as follows
+
+        origin git@github.com:<credential_repository_org>/<credential_repository_name>.git (fetch)
+        origin git@github.com:<credential_repository_org>/<credential_repository_name>.git (push)
+        dummy git@github.com:integr8ly/tower_dummy_credentials.git (fetch)
+        dummy git@github.com:integr8ly/tower_dummy_credentials.git (push)
+
+   Remote setup command example
+
+        git remote add dummy https://github.com/integr8ly/tower_dummy_credentials.git
+
+3. Update master branch of the forked private credentials repository
+
+        git reset --hard
+        git checkout master
+        git pull origin master
+        git fetch --all -p
+
+4. Checkout Makefiles and scripts from target release tag
+
+        git checkout <release-tag> -- Makefile scripts/
+        chmod +x scripts/*
+
+5. Run make sync task to update to a specific release tag, responding to all prompts accordingly.
+
+   **NOTE:** The vault password to the credentials repository is required to complete this step.
+
+        make sync releasetag=<release-tag>
+
+   During this task, the user will be prompted to review the CHANGELOG for the specified release tag and update the local `CREDENTIAL_CONFIG.yml` file accordingly.
+
+   Once the `make sync` task has completed, a new release base branch and associated release tag should be available from the credential repository
+
+   For example:
+
+        Base Branch: v99.99
+        Release Tag: release-99.99.99
+
+6. Once happy that the generated release tag and base branch have been created successfully against `origin` remote of the forked private credentials repository, complete the following:
+
+* Issue a PR against master from the base branch e.g. `v99.99`
+* Carefully review all changes as part of the PR
+* Merge back to master when ready

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+REMOTE=${REMOTE:-origin}
+BRANCH=${branch:-credential_cleandown}
+CLEAN_FILES=(VARIABLES.md README.md CHANGELOG.md CREDENTIAL_CONFIG_TEMPLATE.yml .github)
+
+function clean {
+    printf "Removing nonessential files and directories: ${CLEAN_FILES[*]}\n"
+    for i in ${CLEAN_FILES[@]}; do
+      rm -rf $i
+    done
+}
+
+function createBranch {
+    # check if the specified from branch already exists if it does check it out otherwise create it
+    printf "Creating branch ${BRANCH} if it doesn't already exist\n"
+    git checkout -b ${BRANCH}
+    if [[ $? > 0 ]]
+    then
+    printf "ERROR: Branch ${BRANCH} already exists on remote ${REMOTE} or locally. Please either remove this branch or specify a different branch with 'make clean branch=<new-branch-name>'\n"
+    exit 1
+fi
+}
+
+function commitChanges {
+    printf "Committing local changes: \"$1\" $2\n"
+    git commit -m "$1" $2
+}
+
+function pushChanges {
+    printf "Pushing committed changes to branch ${REMOTE}/${BRANCH}\n"
+    git push ${REMOTE} ${BRANCH}
+}
+
+function main {
+    createBranch
+    clean
+    commitChanges 'Removing nonessential files and directories' "${CLEAN_FILES[*]}"
+    pushChanges
+}
+
+main

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+REMOTE_ORIGIN='origin'
+REMOTE_UPSTREAM='dummy'
+SYNC_FILES=(bootstrap.yml files/ roles/)
+DUMMY_REPO_URL="git@github.com:integr8ly/tower_dummy_credentials.git"
+RELEASE_TAG=${releasetag}
+CREDENTIAL_CONFIG_FILE='CREDENTIAL_CONFIG.yml'
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD)
+CHANGELOG_URL="https://raw.githubusercontent.com/integr8ly/tower_dummy_credentials/${RELEASE_TAG}/CHANGELOG.md"
+
+function sanityCheck {
+  # Validate RELEASE_TAG parameter
+  if [ ${RELEASE_TAG} == "" ]
+  then
+    printf "Please specify a release tag: 'make sync releasetag=<release-tag>'\n"
+    exit 1
+  fi
+
+  # Validate RELEASE_TAG format
+  if [[ $RELEASE_TAG =~ ^release-([0-9]+).([0-9]+).([0-9]+)-?(.*)?$ ]]; then
+    MAJOR_VERSION=${BASH_REMATCH[1]}
+    MINOR_VERSION=${BASH_REMATCH[2]}
+    PATCH_VERSION=${BASH_REMATCH[3]}
+    LABEL_VERSION=${BASH_REMATCH[4]}
+  else
+    printf "Invalid release tag $RELEASE_TAG\n"
+    exit 1
+  fi
+}
+
+function setup {
+  printf "Adding ${REMOTE_UPSTREAM} remote\n"
+  git remote add ${REMOTE_UPSTREAM} ${DUMMY_REPO_URL}
+  git fetch --all -p
+
+  BASE_BRANCH=v$MAJOR_VERSION.$MINOR_VERSION
+  git checkout -B ${BASE_BRANCH} ${REMOTE_ORIGIN}/${BASE_BRANCH}
+  if [[ $? > 0 ]]
+  then
+    printf "Creating release base branch: ${BASE_BRANCH}\n"
+    git checkout -b ${BASE_BRANCH}
+  else
+    read -p "Release branch ${REMOTE_ORIGIN}/${BASE_BRANCH} already exists. Are you sure you want to continue (y|n)?"
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+      printf "Aborting\n"
+      exit 1
+    fi
+    printf "Release branch ${REMOTE_ORIGIN}/${BASE_BRANCH} exists. Checking out locally..\n"
+    git checkout ${BASE_BRANCH}
+  fi
+}
+
+function syncFiles {
+  printf "Syncing files ${SYNC_FILES[*]}\n"
+  for i in ${SYNC_FILES[@]}; do
+    git checkout ${RELEASE_TAG} -- $i
+  done
+}
+
+function decryptConfigFile {
+  printf "\nDecrypting Credential Config File: ${CREDENTIAL_CONFIG_FILE}\n"
+  ansible-vault decrypt ${CREDENTIAL_CONFIG_FILE} --ask-vault-pass
+}
+
+function updateConfigFile {
+  curl ${CHANGELOG_URL}
+  printf "\n=============================\n\nSTEPS\n1. Please review the above CHANGELOG output and ensure that any new variables listed are manually added to $(pwd)/CREDENTIAL_CONFIG.yml\n\nFor reference, check the following files:\nCREDENTIAL_CONFIG_TEMPLATE.yml: https://github.com/integr8ly/tower_dummy_credentials/blob/${RELEASE_TAG}/CREDENTIAL_CONFIG_TEMPLATE.yml\nVARIABLES.md: https://github.com/integr8ly/tower_dummy_credentials/blob/${RELEASE_TAG}/VARIABLES.md\n\n=============================\n"
+  read -p "Perform the STEPS listed above. Continue (y|n)?"
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+    printf "Aborting\n"
+    exit 1
+  fi
+}
+
+function bootstrap {
+  printf "Running bootstrap process with updated configuration\n"
+  ansible-playbook -i ./inventories/hosts bootstrap.yml --extra-vars='@CREDENTIAL_CONFIG.yml'
+}
+
+function commitChanges {
+    printf "Adding new local files\n"
+    git add .
+    printf "Committing local changes\n"
+    git commit -am "$1"
+}
+
+function pushChanges {
+    printf "Pushing committed changes to branch ${REMOTE_ORIGIN}/${BASE_BRANCH}\n"
+    git push ${REMOTE_ORIGIN} ${BASE_BRANCH}
+}
+
+function createReleaseTag {
+    printf "Update release tag ${releasetag} on remote ${REMOTE_ORIGIN}\n"
+    # Removing local reference to releasetag as this will conflict with upstream dummy cred repo release tag
+    git tag -d ${releasetag}
+    git tag ${releasetag}
+    git push ${REMOTE_ORIGIN} ${releasetag}
+}
+
+function main {
+  sanityCheck
+  setup
+  syncFiles
+  decryptConfigFile
+  updateConfigFile
+  bootstrap
+  commitChanges "Syncing repo with release ${releasetag}"
+  pushChanges
+  createReleaseTag
+}
+
+main


### PR DESCRIPTION
**Summary**
We need a formal process for updating private credentials repositories with the latest changes from the tower dummy credentials repository. The purpose of this PR is to automate this process via a set of Makefiles

**Changes**
`make clean` job for removing non-essential files such as README etc.
`make sync` job for updating to a specific releasetag on the dummy credentials repository

**Validation**
All validation should be performed based on the updated README steps in this PR

**Test 1**
- [ ] Review the updated `Setup` section of the README and ensure all makes sense. This includes running new `make clean` task which will get run as part of Test 2

**Test 2**
- [ ] Run the `make clean` task from the `master` branch of `integreatly_dev` **Not from this PR branch**
```
git remote add dummy https://github.com/integr8ly/tower_dummy_credentials.git
git fetch --all -p
git checkout release-99.99.99 -- Makefile scripts/
chmod +x scripts/*
make clean
```
_Expected Result_
A new branch named `credential_cleandown`should exist on remote `origin` of `integreatly_dev` which removes non-essential files and directories

**Test 3**
- [ ] Follow the steps listed in the `updating-private-credential-repositories` section of the README against the `integreatly_dev` repo based on a release tag `release-99.99.99` which is already available from the dummy credentials repo. 

NOTE: A new variable named `dummy_release_variable` was added to this tag so make sure to update accordingly when prompted by the `make sync` task

_Expected Result_
The following should exist on `integreatly_dev` after the sync:
```
 Base Branch: v99.99
 Release Tag: release-99.99.99
```
