### PR TITLE
Adding PR template file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Additional Information
+<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
+
+## Verification Steps
+As the verifier of the PR the following process should be done:
+
+## Checklist
+<!-- If a new variable is being introduced, it must be added to the CHANGELOG in addition to the steps outlined in the README for adding a new variable -->
+
+- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)


### PR DESCRIPTION
**Summary**
Recently a CHANGELOG file was introduced for tracking new variables on each release. We need to ensure that any new PR that includes a new variable is added to the CHANGELOG. This PR template will serve as a reminder to do this.