### PR TITLE
Adding correct CHANGELOG link to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@ As the verifier of the PR the following process should be done:
 ## Checklist
 <!-- If a new variable is being introduced, it must be added to the CHANGELOG in addition to the steps outlined in the README for adding a new variable -->
 
-- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
+- [ ] Updated [CHANGELOG](https://github.com/integr8ly/tower_dummy_credentials/blob/master/CHANGELOG.md)


### PR DESCRIPTION
## Additional Information
The PR template contains an incorrect URL for the CHANGELOG file.

## Verification Steps
As the verifier of the PR the following process should be done:

N/A

## Checklist
<!-- If a new variable is being introduced, it must be added to the CHANGELOG in addition to the steps outlined in the README for adding a new variable -->

- [ ] Updated [Changelog](https://github.com/integr8ly/installation/blob/master/CHANGELOG.md)
