### PR TITLE
move license to dummy credentiasl repo

### DIFF
--- a/CREDENTIAL_CONFIG_TEMPLATE.yml
+++ b/CREDENTIAL_CONFIG_TEMPLATE.yml
@@ -80,6 +80,7 @@ dummy_tower_password: <CHANGEME>
 # dummy_tower_license
 # Note: `"eula_accepted": true` is required in your license json but is not included when sent.
 # Replace <CHANGE_ME> with your license json but keep the `"eula_accepted": true` entry
+# Apply for a license here: https://store.ansible.com/redhat/tower_license/ using @redhat.com address
 dummy_tower_license: |
   {
     <CHANGE_ME>,


### PR DESCRIPTION
## Additional Information
https://issues.redhat.com/browse/INTLY-5025

**Commits/Changes**
1. Moving license step to dummy repo - [related commit](https://github.com/RHCloudServices/integreatly-help/pull/384/commits/9a71c71f89224fe728e857acbde2f58ee43161aa)

## Verification Steps
Docs Updates - no verification steps for now

## Checklist

- [ ] Updated [CHANGELOG](https://github.com/integr8ly/tower_dummy_credentials/blob/master/CHANGELOG.md)
